### PR TITLE
TABS2-5266

### DIFF
--- a/src/common/Booking.js
+++ b/src/common/Booking.js
@@ -364,6 +364,10 @@ Booking.prototype.getStatus = function() {
       item.showAs = 'cancelled';
     }
   }
+  // TABS2-5266
+  if (this.status === 'Provisional Accepted') {
+    item.showAs = 'provisionalaccepted';
+  }
   // TBD - Web bookings, flexilet
 
   return item;


### PR DESCRIPTION
- Added case for setting booking 'showAs' prop for provisional accepted status.

Needs to be released with tabs pull request https://github.com/CarltonSoftware/react-prototype/pull/423.