### PR TITLE
TABS2-5638 hotfix: prevent error being shown when .name is undefined

### DIFF
--- a/src/common/Booking.js
+++ b/src/common/Booking.js
@@ -371,7 +371,7 @@ Booking.prototype.getStatus = function() {
       }
       item.showAs = 'owner';
 
-      if (this.ownerbookingtype && this.ownerbookingtype.name.substring(0, 6).toLowerCase() === 'buffer') {
+      if (this.ownerbookingtype && this.ownerbookingtype.name && this.ownerbookingtype.name.substring(0, 6).toLowerCase() === 'buffer') {
         item.showAs = 'bookingbuffer';
       }
       break;


### PR DESCRIPTION
Uncaught (in promise) TypeError: Cannot read property 'substring' of undefined