### PR TITLE
CORE-142 Fix: changed API call path structure.

### DIFF
--- a/src/common/Complaint.js
+++ b/src/common/Complaint.js
@@ -3,7 +3,9 @@ var Joi = require('joi');
 var EntityLink = require('./EntityLink');
 var ComplaintSource = require('./ComplaintSource');
 var ComplaintReason = require('./ComplaintReason');
+var ComplaintSelectedReason = require('./ComplaintSelectedReason');
 var ComplaintHolidayStatus = require('./ComplaintHolidayStatus');
+var Collection = require('./Collection');
 
 function Complaint(id) {
   this.path = 'complaint';
@@ -18,6 +20,11 @@ function Complaint(id) {
   this.source = new ComplaintSource();
   this.reason = new ComplaintReason();
   this.complaintholidaystatus = new ComplaintHolidayStatus();
+  this.selectedreasons = new Collection({
+    object: ComplaintSelectedReason,
+    path: 'selectedreason',
+    parent: this,
+  })
 }
 Complaint.prototype = new SingleEntity();
 

--- a/src/common/ComplaintSelectedReason.js
+++ b/src/common/ComplaintSelectedReason.js
@@ -1,24 +1,24 @@
 var SingleEntity = require('./SingleEntity');
 var Joi = require('joi');
+var ComplaintReason = require('./ComplaintReason');
 
 function ComplaintSelectedReason(id) {
-  this.path = 'complaintselectedreason';
-  this.createPath = 'complaintselectedreason';
+  this.path = 'selectedreason';
+  this.createPath = this.path;
   this.id = id;
+  this.complaintreason = new ComplaintReason();
 }
 ComplaintSelectedReason.prototype = new SingleEntity();
 
 ComplaintSelectedReason.prototype.validSchema = function() {
   return {
-    complaintreasonid: Joi.number().required().label('Complaint Reason Id'),
-    complaintid: Joi.number().required().label('Complaint Id')
+    complaintreason: Joi.number().required().label('Complaint Reason')
   };
 };
 
 ComplaintSelectedReason.prototype.toArray = function() {
   return {
-    complaintreasonid: this.complaintreasonid,
-    complaintid: this.complaintid
+    complaintreasonid: this.complaintreason.id
   };
 };
 


### PR DESCRIPTION
From the previous PR:
Hi @TWhittingtonTOCC, couple of issues with this:

complaintreasonid should be treated as an object rather than the front-end passing in complaintreasonid. This is best demonstrated with an example - see how WorkOrderSupplier is dealt with in https://github.com/CarltonSoftware/plato-js-client/blob/master/src/common/WorkOrder.js

the API route for ComplaintSelectedReason should be complaint/id/selectedreason, meaning there shouldn't be any reference to complaintid in the plato-js-client ComplaintSelectedReason.js file. Instead, when you're creating a ComplaintSelectedReason in the frontend you would set the Complaint as the parent, and the client sorts the rest out for you. I guess you'll probably have to change plato to sort this out, IF what you have in ComplaintSelectedReason.js is working! Example would be WorkOrderExpense, which in the API is workorder/id/expense. https://github.com/CarltonSoftware/plato-js-client/blob/master/src/common/WorkOrderExpense.js

