### PR TITLE
Fix: don't send amount if it isn't set to SpecialOfferBranding

### DIFF
--- a/src/common/SpecialOfferBranding.js
+++ b/src/common/SpecialOfferBranding.js
@@ -17,4 +17,17 @@ SpecialOfferBranding.prototype.toArray = function() {
   };
 };
 
+SpecialOfferBranding.prototype.toCreateArray = function() {
+  // don't send the amount if it isn't set as the API misinterprets this as zero
+  if (this.amount) {
+    return this.toArray();
+  }
+
+  return {
+    brandingid: this.branding.id,
+    description: this.description,
+    active: this.active,
+  };
+};
+
 module.exports = SpecialOfferBranding;


### PR DESCRIPTION
The API currently interprets an empty amount as £0 and overrides the actual special offer amount. This only sends the amount if it contains a value.